### PR TITLE
resolve disk and cluster location mismatch

### DIFF
--- a/akslabs_scripts/aks-flp-storage.sh
+++ b/akslabs_scripts/aks-flp-storage.sh
@@ -181,6 +181,7 @@ function lab_scenario_1 () {
     az disk create \
     --resource-group $RESOURCE_GROUP \
     --name datadisk1 \
+    --location $LOCATION \
     --size-gb 5 &>/dev/null
     DISK_URI="$(az disk show -g $RESOURCE_GROUP -n datadisk1 -o tsv --query id)"
 


### PR DESCRIPTION
The `az disk create` command within the `aks-flp-storage.sh` script was missing the location flag, causing the disk to be deployed in the resource group location instead of the aks cluster location. This resulted in a `FailedAttachVolume` error with the following message:
`"error": {\r
    "code": "NotFound",\r
    "message": "The entity was not found in this Azure location."`